### PR TITLE
Fix "only variables should be passed by reference" error

### DIFF
--- a/src/JsonSchemaValidator.php
+++ b/src/JsonSchemaValidator.php
@@ -137,7 +137,8 @@ class JsonSchemaValidator extends Validator
         $validator->check($value, $schema);
 
         if (!$validator->isValid()) {
-            $error = reset($validator->getErrors());
+            $errors = $validator->getErrors();
+            $error = reset($errors);
             return [$this->message, ['property' => $error['property'], 'message' => ucfirst($error['message'])]];
         }
 


### PR DESCRIPTION
Using `reset()` on method calls directly results in a PHP notice since `reset()` expects a reference rather than a copy.
